### PR TITLE
Changement du container des highscores (std::map -> std::multimap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Now, things are going to get a little bit more harder. We need to make the `Wind
 
 ### The render target
 
-The render target is basically the engine you will use to render objects to the screen (SFML, nCurses, OpenGL, etc.). The implementation of the `RenderTarget` class is up to you, but let's see one possible implementation :
+The render target is basically the engine you will use to render objects to the screen (SFML, nCurses, OpenGL, etc.) :
 
 ```cpp
 class RenderTarget

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ scores = game->highscores();
 // Then save them
 ```
 
-Here, `Game::Scores` is a `std::map<std::uint64_t, std::string>`.
+Here, `Game::Scores` is a `std::multimap<std::uint64_t, std::string>`.
 
 # Events
 

--- a/include/Engine/Renderer/RenderTarget.hpp
+++ b/include/Engine/Renderer/RenderTarget.hpp
@@ -9,6 +9,9 @@
 
 namespace engine
 {
+	class Sprite;
+	class Text;
+
 	class RenderTarget
 	{
 	public:
@@ -21,6 +24,16 @@ namespace engine
 		RenderTarget &operator=(RenderTarget const &) = delete;
 		RenderTarget &operator=(RenderTarget &&) = default;
 
-		// Implementation is up to you...
+		/**
+		 * \brief Draw a sprite into the render target.
+		 * \param Sprite
+		 */
+		virtual void drawSprite(Sprite const &sprite) = 0;
+
+		/**
+		 * \brief Draw a text into the render target.
+		 * \param Text
+		 */
+		virtual void drawText(Text const &text) = 0;
 	};
 }

--- a/include/Engine/Renderer/Sprite.hpp
+++ b/include/Engine/Renderer/Sprite.hpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "Drawable.hpp"
+#include "RenderTarget.hpp"
 #include "Transformable.hpp"
 #include "Vector.hpp"
 
@@ -27,9 +28,29 @@ namespace engine
 		Sprite &operator=(Sprite const &) = delete;
 		Sprite &operator=(Sprite &&) = default;
 
-		// Here you'll need to specifiy the prototypes of the pure
-		// virtual member functions inherited from Transformable and
-		// Drawable
+		/**
+		 * \brief Draw itself into the given renderer.
+		 * \param RenderTarget target
+		 */
+		void draw(RenderTarget &renderer) const;
+
+		/**
+		 * \brief Move the transformable to the given position.
+		 * \param Vector2f newPos
+		 */
+		void moveTo(Vector2f const &newPos);
+
+		/**
+		 * \brief Move the transformable by the given offset.
+		 * \param Vector2f offset
+		 */
+		void move(Vector2f const &offset);
+
+		/**
+		 * \brief Get the transformable current position.
+		 * \return Vector2f
+		 */
+		Vector2f const &getPosition() const;
 
 		/**
 		 * \brief Set the image file path.
@@ -50,9 +71,9 @@ namespace engine
 		void setSize(Vector2f const &size);
 
 		/**
-		* \brief Set the sprite rotation.
-		* \param std::size_t rotation
-		*/
+		 * \brief Set the sprite rotation.
+		 * \param std::size_t rotation
+		 */
 		void setRotation(float rotation);
 
 		/**
@@ -74,9 +95,25 @@ namespace engine
 		Vector2f const &getSize() const;
 
 		/**
-		* \brief Get the sprite rotation.
-		* \return float
-		*/
+		 * \brief Get the sprite rotation.
+		 * \return float
+		 */
 		float getRotation() const;
+
+	private:
+		// Image path
+		std::string m_imageFile;
+
+		// Ascii image path
+		std::string m_asciiFile;
+
+		// Sprite position
+		Vector2f m_position;
+
+		// Sprite size (width and height)
+		Vector2f m_size;
+
+		// Sprite rotation (degrees)
+		float m_rotation;
 	};
 }

--- a/include/Engine/Renderer/Text.hpp
+++ b/include/Engine/Renderer/Text.hpp
@@ -11,6 +11,7 @@
 
 #include "Color.hpp"
 #include "Drawable.hpp"
+#include "RenderTarget.hpp"
 #include "Transformable.hpp"
 #include "Vector.hpp"
 
@@ -28,9 +29,29 @@ namespace engine
 		Text &operator=(Text const &) = delete;
 		Text &operator=(Text &&) = default;
 
-		// Here you'll need to specifiy the prototypes of the pure
-		// virtual member functions inherited from Transformable and
-		// Drawable
+		/**
+		 * \brief Draw itself into the given renderer.
+		 * \param RenderTarget target
+		 */
+		void draw(RenderTarget &renderer) const;
+
+		/**
+		 * \brief Move the transformable to the given position.
+		 * \param Vector2f newPos
+		 */
+		void moveTo(Vector2f const &newPos);
+
+		/**
+		 * \brief Move the transformable by the given offset.
+		 * \param Vector2f offset
+		 */
+		void move(Vector2f const &offset);
+
+		/**
+		 * \brief Get the transformable current position.
+		 * \return Vector2f
+		 */
+		Vector2f const &getPosition() const;
 
 		/**
 		 * \brief Set the text value.
@@ -79,5 +100,21 @@ namespace engine
 		 * \return Color
 		 */
 		Color const &getColor() const;
+
+	private:
+		// Text value
+		std::string m_text;
+
+		// Font path
+		std::string m_font;
+
+		// Text position
+		Vector2f m_position;
+
+		// Font size
+		std::size_t m_size;
+
+		// Font color
+		Color m_color;
 	};
 }

--- a/include/Game/Game.hpp
+++ b/include/Game/Game.hpp
@@ -19,7 +19,7 @@ namespace arcade
 	class Game
 	{
 	public:
-		using Scores = std::map<std::uint64_t, std::string>;
+		using Scores = std::multimap<std::uint64_t, std::string>;
 
 		Game() = default;
 		virtual ~Game() = default;


### PR DESCRIPTION
Le fait que les clés de `std::map` soient uniques ne permet pas d'avoir deux fois le même score de la part de deux joueurs différents, voire du même joueur.
La conversion en `std::multimap` règle ce problème.